### PR TITLE
Adfs properites

### DIFF
--- a/adfs-management/adfs-management.psd1
+++ b/adfs-management/adfs-management.psd1
@@ -6,9 +6,6 @@
     Copyright = 'GNU General Public License v3.0'
     Description = 'Contains functions that help export and import settings in ADFS.  Helps with IaC scenarios.'
     PowerShellVersion = '4.0'
-    RequiredModules = @(
-      @{ModuleName="ADFS"; ModuleVersion="1.0.0.0"}
-    )
     NestedModules = @(
       '.\functions\Convertorganization.ps1',
       '.\functions\Convertperson.ps1',

--- a/adfs-management/adfs-management.psd1
+++ b/adfs-management/adfs-management.psd1
@@ -7,8 +7,8 @@
     Description = 'Contains functions that help export and import settings in ADFS.  Helps with IaC scenarios.'
     PowerShellVersion = '4.0'
     NestedModules = @(
-      '.\functions\Convertorganization.ps1',
-      '.\functions\Convertperson.ps1',
+      '.\functions\convertorganization.ps1',
+      '.\functions\convertperson.ps1',
       '.\functions\Copy-ADFSClaimRule.ps1',
       '.\functions\Export-ADFSClaimRule.ps1',
       '.\functions\Export-ADFSClient.ps1',

--- a/adfs-management/adfs-management.psd1
+++ b/adfs-management/adfs-management.psd1
@@ -6,6 +6,9 @@
     Copyright = 'GNU General Public License v3.0'
     Description = 'Contains functions that help export and import settings in ADFS.  Helps with IaC scenarios.'
     PowerShellVersion = '4.0'
+    RequiredModules = @(
+      @{ModuleName="ADFS"; ModuleVersion="1.0.0.0"}
+    )
     NestedModules = @(
       '.\functions\Convertorganization.ps1',
       '.\functions\Convertperson.ps1',

--- a/adfs-management/adfs-management.psd1
+++ b/adfs-management/adfs-management.psd1
@@ -10,16 +10,20 @@
       '.\functions\Copy-ADFSClaimRule.ps1',
       '.\functions\Export-ADFSClaimRule.ps1',
       '.\functions\Export-ADFSClient.ps1',
+      '.\functions\Export-ADFSProperties.ps1',
       '.\functions\Import-ADFSClaimRule.ps1',
       '.\functions\Import-ADFSClient.ps1',
+      '.\functions\Import-ADFSProperties.ps1',
       '.\functions\sessionconfig.ps1'
     )
     FunctionsToExport = @(
       'Copy-ADFSClaimRule',
       'Export-ADFSClaimRule',
       'Export-ADFSClient',
+      'Export-ADFSProperties',
       'Import-ADFSClaimRule',
-      'Import-ADFSClient'
+      'Import-ADFSClient',
+      'Import-ADFSProperties'
     )
     PrivateData = @{
       PSData = @{

--- a/adfs-management/adfs-management.psd1
+++ b/adfs-management/adfs-management.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion = '1.1.0'
+    ModuleVersion = '1.2.0'
     GUID = '0ad55c54-b693-4636-9375-4877987bfdb0'
     Author = 'Justin King'
     CompanyName = 'Unknown'
@@ -7,6 +7,8 @@
     Description = 'Contains functions that help export and import settings in ADFS.  Helps with IaC scenarios.'
     PowerShellVersion = '4.0'
     NestedModules = @(
+      '.\functions\Convertorganization.ps1',
+      '.\functions\Convertperson.ps1',
       '.\functions\Copy-ADFSClaimRule.ps1',
       '.\functions\Export-ADFSClaimRule.ps1',
       '.\functions\Export-ADFSClient.ps1',

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -71,6 +71,7 @@
                 }
                 $returnProperties[$tmpName] = $timeSpanObject
               }
+              ClientCertRevocationCheck { $returnProperties[$tmpName] = "$($SourceProperties.ClientCertRevocationCheck)" }
               ContactPerson { $returnProperties[$tmpName] = convertperson -Method tocustom -Contact $tmpValue }
               OrganizationInfo { $returnProperties[$tmpName] = convertorganization -Method tocustom -Organization $tmpValue }
               PersistentSsoCutoffTime { [string]$returnProperties[$tmpName] = $tmpValue.Date }

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -71,7 +71,7 @@
                 }
                 $returnProperties[$tmpName] = $timeSpanObject
               }
-              PersistentSsoCutoffTime { $importSplat[$tmpName] = $tmpValue.Date }
+              PersistentSsoCutoffTime { $returnProperties[$tmpName] = $tmpValue.Date }
               default { $returnProperties[$tmpName] = $tmpValue }
             }
           }

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -59,7 +59,16 @@
             $tmpName = $_.Name
             $tmpValue = $_.Value
             switch ($tmpName) {
-              # ClientType { $returnProperties[$tmpName] = "$($SourceProperties.ClientType)" }
+              ExtranetObservationWindow {
+                # time timespan object down to relevent data only
+                $timeSpanObject = New-Object -TypeName PSObject -Property @{
+                  Days = $tmpValue.Days
+                  Hours = $tmpValue.Hours
+                  Minutes = $tmpValue.Minutes
+                  Seconds = $tmpValue.Seconds
+                }
+                $returnProperties[$tmpName] = $timeSpanObject
+              }
               default { $returnProperties[$tmpName] = $tmpValue }
             }
           }
@@ -68,15 +77,6 @@
           $returnProperties.Remove("PSComputerName")
           $returnProperties.Remove("PSShowComputerName")
           $returnProperties.Remove("RunspaceId")
-
-          #trim timespan information on running data
-          $returnProperties.ExtranetObservationWindow.Remove("Ticks")
-          $returnProperties.ExtranetObservationWindow.Remove("Milliseconds")
-          $returnProperties.ExtranetObservationWindow.Remove("TotalDays")
-          $returnProperties.ExtranetObservationWindow.Remove("TotalHours")
-          $returnProperties.ExtranetObservationWindow.Remove("TotalMilliseconds")
-          $returnProperties.ExtranetObservationWindow.Remove("TotalMinutes")
-          $returnProperties.ExtranetObservationWindow.Remove("TotalSeconds")
 
           # convert the whole thing down to JSON
           $returnProperties = $returnProperties | ConvertTo-Json

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -71,7 +71,7 @@
                 }
                 $returnProperties[$tmpName] = $timeSpanObject
               }
-              PersistentSsoCutoffTime { $returnProperties[$tmpName] = $tmpValue.Date }
+              PersistentSsoCutoffTime { [string]$returnProperties[$tmpName] = $tmpValue.Date }
               default { $returnProperties[$tmpName] = $tmpValue }
             }
           }

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -69,6 +69,16 @@
           $returnProperties.Remove("PSShowComputerName")
           $returnProperties.Remove("RunspaceId")
 
+          #trim timespan information on running data
+          $returnProperties.ExtranetObservationWindow.Remove("Ticks")
+          $returnProperties.ExtranetObservationWindow.Remove("Milliseconds")
+          $returnProperties.ExtranetObservationWindow.Remove("TotalDays")
+          $returnProperties.ExtranetObservationWindow.Remove("TotalHours")
+          $returnProperties.ExtranetObservationWindow.Remove("TotalMilliseconds")
+          $returnProperties.ExtranetObservationWindow.Remove("TotalMinutes")
+          $returnProperties.ExtranetObservationWindow.Remove("TotalSeconds")
+
+          # convert the whole thing down to JSON
           $returnProperties = $returnProperties | ConvertTo-Json
         }
         Else {

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -80,12 +80,12 @@
             }
           }
 
-          # apply Contact and Org, as those require custom objects to be defined
+          # process Contact and Org, as those require custom objects to be defined
           If ($SourceProperties.ContactPerson) {
-            convertperson -Method getcustom -SessionInfo $sessioninfo
+            $returnProperties.ContactPerson = convertperson -Method getcustom -SessionInfo $sessioninfo
           }
           If ($SourceProperties.OrganizationInfo) {
-            convertorganization -Method getcustom -SessionInfo $sessioninfo
+            $returnProperties.OrganizationInfo = convertorganization -Method getcustom -SessionInfo $sessioninfo
           }
 
           #remove psremote info if present

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -55,12 +55,14 @@
           $returnProperties = @{}
           $SourceProperties.psobject.properties | ForEach-Object { 
 
-            #certain fields are custom objects and must be exported as string to ensure they import properly
+            # some parameters are not simple strings and need conversion
+            # Others are informational only and should be trimmed
+            # Do that work here.
             $tmpName = $_.Name
             $tmpValue = $_.Value
             switch ($tmpName) {
               ExtranetObservationWindow {
-                # time timespan object down to relevent data only
+                # trim timespan object down to relevent data only
                 $timeSpanObject = New-Object -TypeName PSObject -Property @{
                   Days = $tmpValue.Days
                   Hours = $tmpValue.Hours
@@ -69,6 +71,7 @@
                 }
                 $returnProperties[$tmpName] = $timeSpanObject
               }
+              PersistentSsoCutoffTime { $importSplat[$tmpName] = $tmpValue.Date }
               default { $returnProperties[$tmpName] = $tmpValue }
             }
           }

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -72,6 +72,7 @@
                 $returnProperties[$tmpName] = $timeSpanObject
               }
               ClientCertRevocationCheck { $returnProperties[$tmpName] = "$($SourceProperties.ClientCertRevocationCheck)" }
+              ExtendedProtectionTokenCheck { $returnProperties[$tmpName] = "$($SourceProperties.ExtendedProtectionTokenCheck)" }
               ContactPerson { $returnProperties[$tmpName] = convertperson -Method tocustom -Contact $tmpValue }
               OrganizationInfo { $returnProperties[$tmpName] = convertorganization -Method tocustom -Organization $tmpValue }
               PersistentSsoCutoffTime { [string]$returnProperties[$tmpName] = $tmpValue.Date }

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -1,0 +1,86 @@
+﻿function Export-ADFSProperties
+{
+  <#
+  .SYNOPSIS
+    This script exports ADFSProperties values with extra authentication rules to allow for remote execution.
+
+  .DESCRIPTION
+    Exports all global properties from farm, with extra local/remote server and credential flags to make it more flexible in a CI/CD scenario.
+
+  .EXAMPLE
+    Export-ADFSProperties
+
+    This will export all global properties in json format for saving in a config-as-code scenario.
+
+  .EXAMPLE
+    Export-ADFSProperties -Name MyClient -Server ADFS01 -Credential $creds
+
+    In this example a remote server and credentials are proivided.  The credential parameter is not mandetory if current logged-in credentails will work.
+  #>
+
+    [CmdletBinding()]
+    Param
+    (
+        [Parameter(Mandatory=$false, ValueFromPipeline=$false)]
+        [string] $Server = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory=$false, ValueFromPipeline=$false)]
+        [System.Management.Automation.PSCredential] $Credential
+    )
+
+    Begin
+    {
+        $ErrorActionPreference = "Stop"
+        $params = @{
+          Method = "open"
+          Server = $Server
+        }
+        If ($Credential) { $params.Credential = $Credential }
+        $sessioninfo = sessionconfig @params
+    }
+
+    Process
+    {
+
+        # gather info using existing cmdlets
+        if ($sessioninfo.SourceRemote){
+            $SourceProperties = Invoke-Command -Session $sessioninfo.SessionData -ScriptBlock { Get-AdfsProperties }
+        }
+        else {
+            $SourceProperties = Get-AdfsProperties
+        }
+
+        # convert cutomobject(s) to a hashtable so it can be easily modified for IAC tasks
+        If ($SourceProperties) {
+          $returnProperties = @{}
+          $SourceProperties.psobject.properties | ForEach-Object { 
+
+            #certain fields are custom objects and must be exported as string to ensure they import properly
+            $tmpName = $_.Name
+            $tmpValue = $_.Value
+            switch ($tmpName) {
+              # ClientType { $returnProperties[$tmpName] = "$($SourceProperties.ClientType)" }
+              default { $returnProperties[$tmpName] = $tmpValue }
+            }
+          }
+
+          #remove psremote info if present
+          $returnProperties.Remove("PSComputerName")
+          $returnProperties.Remove("PSShowComputerName")
+          $returnProperties.Remove("RunspaceId")
+
+          $returnProperties = $returnProperties | ConvertTo-Json
+        }
+        Else {
+          Write-Warning "query returned empty, please verify parameters."
+        }
+    }
+
+    End
+    {
+      #tear down sessions
+      sessionconfig -Method close -SessionInfo $sessioninfo
+
+      return $returnProperties
+    }
+}

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -71,6 +71,8 @@
                 }
                 $returnProperties[$tmpName] = $timeSpanObject
               }
+              ContactPerson { $returnProperties[$tmpName] = convertperson -Method tocustom -Contact $tmpValue }
+              OrganizationInfo { $returnProperties[$tmpName] = convertorganization -Method tocustom -Organization $tmpValue }
               PersistentSsoCutoffTime { [string]$returnProperties[$tmpName] = $tmpValue.Date }
               default { $returnProperties[$tmpName] = $tmpValue }
             }

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -73,11 +73,19 @@
               }
               ClientCertRevocationCheck { $returnProperties[$tmpName] = "$($SourceProperties.ClientCertRevocationCheck)" }
               ExtendedProtectionTokenCheck { $returnProperties[$tmpName] = "$($SourceProperties.ExtendedProtectionTokenCheck)" }
-              ContactPerson { $returnProperties[$tmpName] = convertperson -Method tocustom -Contact $tmpValue }
-              OrganizationInfo { $returnProperties[$tmpName] = convertorganization -Method tocustom -Organization $tmpValue }
+              ContactPerson {} # skip this, we transform it later
+              OrganizationInfo {} # skip this, we transform it later
               PersistentSsoCutoffTime { [string]$returnProperties[$tmpName] = $tmpValue.Date }
               default { $returnProperties[$tmpName] = $tmpValue }
             }
+          }
+
+          # apply Contact and Org, as those require custom objects to be defined
+          If ($SourceProperties.ContactPerson) {
+            convertperson -Method getcustom -SessionInfo $sessioninfo
+          }
+          If ($SourceProperties.OrganizationInfo) {
+            convertorganization -Method getcustom -SessionInfo $sessioninfo
           }
 
           #remove psremote info if present

--- a/adfs-management/functions/Import-ADFSProperties.ps1
+++ b/adfs-management/functions/Import-ADFSProperties.ps1
@@ -70,28 +70,6 @@
       $ConvertedContent.PersistentSsoCutoffTime = Get-Date -Date $ConvertedContent.PersistentSsoCutoffTime
     }
 
-    Write-Verbose "translating Organization..."
-    If ($null -ne $ConvertedContent.OrganizationInfo) {
-      $splat = @{}
-      $ConvertedContent.OrganizationInfo.psobject.properties | ForEach-Object {
-        If ($null -ne $_Value) {
-          $splat[$_.Name] = $_.Value
-        }
-      }
-      $ConvertedContent.OrganizationInfo = New-AdfsOrganization @splat
-    }
-
-    Write-Verbose "translating ContactPerson..."
-    If ($null -ne $ConvertedContent.ContactPerson) {
-      $splat = @{}
-      $ConvertedContent.ContactPerson.psobject.properties | ForEach-Object {
-        If ($null -ne $_Value) {
-          $splat[$_.Name] = $_.Value
-        }
-      }
-      $ConvertedContent.ContactPerson = New-AdfsContactPerson @splat
-    }
-
     # Some attributes have parameter naming discrepencies.
     # Do that work here.
     $importSplat = @{}
@@ -100,9 +78,11 @@
       $tmpValue = $_.Value
       switch ($tmpName) {
         CertificateSharingContainer {} # has no equivelent import value
+        ContactPerson { $importSplat[$tmpName] = convertperson -Method fromcustom -Contact $tmpValue }
         ExtranetLockoutEnabled { $importSplat.EnableExtranetLockout = $tmpValue }
         KmsiEnabled { $importSplat.EnableKmsi = $tmpValue }
         LoopDetectionEnabled {$importSplat.EnableLoopDetection = $tmpValue }
+        OrganizationInfo { $importSplat[$tmpName] = convertorganization -Method fromcustom -Organization $tmpValue }
         PersistentSsoEnabled {$importSplat.EnablePersistentSso = $tmpValue }
         InstalledLanguage {} # has no equivelent import value
         PasswordValidationDelayInMinutes {} # has no equivelent import value

--- a/adfs-management/functions/Import-ADFSProperties.ps1
+++ b/adfs-management/functions/Import-ADFSProperties.ps1
@@ -63,7 +63,7 @@
       $tmpValue = $_.Value
       switch ($tmpName) {
         CertificateSharingContainer {} # has no equivelent import value
-        ExtranetLockoutEnabled { importSplat.EnableExtranetLockout = $tmpValue }
+        ExtranetLockoutEnabled { $importSplat.EnableExtranetLockout = $tmpValue }
         KmsiEnabled { $importSplat.EnableKmsi = $tmpValue }
         LoopDetectionEnabled {$importSplat.EnableLoopDetection = $tmpValue }
         PersistentSsoEnabled {$importSplat.EnablePersistentSso = $tmpValue }

--- a/adfs-management/functions/Import-ADFSProperties.ps1
+++ b/adfs-management/functions/Import-ADFSProperties.ps1
@@ -1,0 +1,92 @@
+﻿function Import-ADFSProperties {
+  <#
+  .SYNOPSIS
+    This script imports ADFSProperties values with extra authentication rules to allow for remote execution.
+
+  .DESCRIPTION
+    Imports all global properties to farm, with extra local/remote server and credential flags to make it more flexible in a CI/CD scenario.
+
+  .EXAMPLE
+    Import-ADFSProperties
+
+    This will import all global properties from json format for saving in a config-as-code scenario.
+
+  .EXAMPLE
+    Import-ADFSProperties -Name MyClient -Server ADFS01 -Credential $creds
+
+    In this example a remote server and credentials are proivided.  The credential parameter is not mandetory if current logged-in credentails will work.
+  #>
+
+  [CmdletBinding()]
+  Param
+  (
+
+    [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, Position = 0)]
+    [Alias("Content", "Properties")]
+    [string] $ADFSContent,
+
+    [Parameter(Mandatory = $false, ValueFromPipeline = $false)]
+    [string] $Server = $env:COMPUTERNAME,
+
+    [Parameter(Mandatory = $false, ValueFromPipeline = $false)]
+    [System.Management.Automation.PSCredential] $Credential
+  )
+
+  Begin {
+    $ErrorActionPreference = "Stop"
+    # Validate $ADFSContent is in JSON format
+    Try {
+      $ConvertedContent = ConvertFrom-Json $ADFSContent
+    }
+    Catch {
+      Write-Error "Content was not supplied as valid JSON, aborting" -ErrorAction Stop
+    }
+
+    # login to remote server if nessisary
+    $params = @{
+      Method = "open"
+      Server = $Server
+    }
+    If ($Credential) { $params.Credential = $Credential }
+    $sessioninfo = sessionconfig @params
+  }
+
+  Process {
+
+    # convert JSON into a splat for import
+    Write-Verbose "importing JSON content..."
+
+    $importSplat = @{}
+    $ConvertedContent.psobject.properties | ForEach-Object { 
+      # some parameters are not named identically to thier respective property.  This allows translation
+      $tmpName = $_.Name
+      $tmpValue = $_.Value
+      switch ($tmpName) {
+        CertificateSharingContainer {} # has no equivelent import value
+        ExtranetLockoutEnabled { importSplat.EnableExtranetLockout = $tmpValue }
+        KmsiEnabled { $importSplat.EnableKmsi = $tmpValue }
+        LoopDetectionEnabled {$importSplat.EnableLoopDetection = $tmpValue }
+        PersistentSsoEnabled {$importSplat.EnablePersistentSso = $tmpValue }
+        InstalledLanguage {} # has no equivelent import value
+        PasswordValidationDelayInMinutes {} # has no equivelent import value
+        default { $importSplat[$tmpName] = $tmpValue }
+      }
+    }
+
+    # apply settings
+    Write-Verbose "applying configuration..."
+    if ($sessioninfo.SourceRemote) {
+      $command = { Set-AdfsProperties @Using:importSplat }
+      Invoke-Command -Session $sessioninfo.SessionData -ScriptBlock $command
+    }
+    else {
+      Set-AdfsProperties @importSplat
+    } # false
+
+  }
+
+  End {
+    #tear down sessions
+    sessionconfig -Method close -SessionInfo $sessioninfo
+  }
+}

--- a/adfs-management/functions/Import-ADFSProperties.ps1
+++ b/adfs-management/functions/Import-ADFSProperties.ps1
@@ -78,11 +78,11 @@
       $tmpValue = $_.Value
       switch ($tmpName) {
         CertificateSharingContainer {} # has no equivelent import value
-        ContactPerson { $importSplat[$tmpName] = convertperson -Method fromcustom -Contact $tmpValue }
+        ContactPerson {} # applied later due to custom object
         ExtranetLockoutEnabled { $importSplat.EnableExtranetLockout = $tmpValue }
         KmsiEnabled { $importSplat.EnableKmsi = $tmpValue }
         LoopDetectionEnabled {$importSplat.EnableLoopDetection = $tmpValue }
-        OrganizationInfo { $importSplat[$tmpName] = convertorganization -Method fromcustom -Organization $tmpValue }
+        OrganizationInfo {} # applied later due to custom object
         PersistentSsoEnabled {$importSplat.EnablePersistentSso = $tmpValue }
         InstalledLanguage {} # has no equivelent import value
         PasswordValidationDelayInMinutes {} # has no equivelent import value
@@ -99,6 +99,14 @@
     else {
       Set-AdfsProperties @importSplat
     } # false
+
+    # apply Contact and Org, as those require custom objects to be defined
+    If ($ConvertedContent.ContactPerson) {
+      convertperson -Method applycustom -Contact $tmpValue -SessionInfo $sessioninfo
+    }
+    If ($ConvertedContent.OrganizationInfo) {
+      convertorganization -Method applycustom -Organization $tmpValue -SessionInfo $sessioninfo
+    }
 
   }
 

--- a/adfs-management/functions/Import-ADFSProperties.ps1
+++ b/adfs-management/functions/Import-ADFSProperties.ps1
@@ -34,8 +34,10 @@
 
   Begin {
     $ErrorActionPreference = "Stop"
+
     # Validate $ADFSContent is in JSON format
     Try {
+      Write-Verbose "importing JSON..."
       $ConvertedContent = ConvertFrom-Json $ADFSContent
     }
     Catch {
@@ -53,31 +55,54 @@
 
   Process {
 
-    # convert JSON into a splat for import
-    Write-Verbose "importing JSON content..."
+    # convert custom objects back into native types if present
+    Write-Verbose "translating TimeSpans..."
+    If ($null -ne $ConvertedContent.ExtranetObservationWindow) {
+      $splat = @{}
+      $ConvertedContent.ExtranetObservationWindow.psobject.properties | ForEach-Object {
+        $splat[$_.Name] = $_.Value 
+      }
+      $ConvertedContent.ExtranetObservationWindow = New-TimeSpan @splat
+    }
 
+    Write-Verbose "translating DateTime..."
+    If ($null -ne $ConvertedContent.PersistentSsoCutoffTime) { 
+      $ConvertedContent.PersistentSsoCutoffTime = Get-Date -Date $tmpValue
+    }
+
+    Write-Verbose "translating Organization..."
+    If ($null -ne $ConvertedContent.OrganizationInfo) {
+      $splat = @{}
+      $ConvertedContent.OrganizationInfo.psobject.properties | ForEach-Object {
+        If ($null -ne $_Value) {
+          $splat[$_.Name] = $_.Value
+        }
+      }
+      $ConvertedContent.OrganizationInfo = New-AdfsOrganization @splat
+    }
+
+    Write-Verbose "translating ContactPerson..."
+    If ($null -ne $ConvertedContent.ContactPerson) {
+      $splat = @{}
+      $ConvertedContent.ContactPerson.psobject.properties | ForEach-Object {
+        If ($null -ne $_Value) {
+          $splat[$_.Name] = $_.Value
+        }
+      }
+      $ConvertedContent.ContactPerson = New-AdfsContactPerson @splat
+    }
+
+    # Some attributes have parameter naming discrepencies.
+    # Do that work here.
     $importSplat = @{}
-    $ConvertedContent.psobject.properties | ForEach-Object { 
-      # some parameters are not simple string imports.
-      # Others have parameter naming discrepencies.
-      # Do that work here.
+    $ConvertedContent.psobject.properties | ForEach-Object {     
       $tmpName = $_.Name
       $tmpValue = $_.Value
       switch ($tmpName) {
         CertificateSharingContainer {} # has no equivelent import value
         ExtranetLockoutEnabled { $importSplat.EnableExtranetLockout = $tmpValue }
-        ExtranetObservationWindow {
-          $timespanSplat = @{
-            Days = $tmpValue.Days
-            Hours = $tmpValue.Hours
-            Minutes = $tmpValue.Minutes
-            Seconds = $tmpValue.Seconds
-          }
-          $importSplat[$tmpName] = New-TimeSpan @timespanSplat
-        }
         KmsiEnabled { $importSplat.EnableKmsi = $tmpValue }
         LoopDetectionEnabled {$importSplat.EnableLoopDetection = $tmpValue }
-        PersistentSsoCutoffTime { $importSplat[$tmpName] = Get-Date -Date $tmpValue }
         PersistentSsoEnabled {$importSplat.EnablePersistentSso = $tmpValue }
         InstalledLanguage {} # has no equivelent import value
         PasswordValidationDelayInMinutes {} # has no equivelent import value

--- a/adfs-management/functions/Import-ADFSProperties.ps1
+++ b/adfs-management/functions/Import-ADFSProperties.ps1
@@ -67,7 +67,7 @@
 
     Write-Verbose "translating DateTime..."
     If ($null -ne $ConvertedContent.PersistentSsoCutoffTime) { 
-      $ConvertedContent.PersistentSsoCutoffTime = Get-Date -Date $tmpValue
+      $ConvertedContent.PersistentSsoCutoffTime = Get-Date -Date $ConvertedContent.PersistentSsoCutoffTime
     }
 
     Write-Verbose "translating Organization..."

--- a/adfs-management/functions/Import-ADFSProperties.ps1
+++ b/adfs-management/functions/Import-ADFSProperties.ps1
@@ -60,7 +60,7 @@
     $ConvertedContent.psobject.properties | ForEach-Object { 
       # some parameters are not simple string imports.
       # Others have parameter naming discrepencies.
-      # Track it all here.
+      # Do that work here.
       $tmpName = $_.Name
       $tmpValue = $_.Value
       switch ($tmpName) {
@@ -73,10 +73,11 @@
             Minutes = $tmpValue.Minutes
             Seconds = $tmpValue.Seconds
           }
-          $importSplat.ExtranetObservationWindow = New-TimeSpan @timespanSplat
+          $importSplat[$tmpName] = New-TimeSpan @timespanSplat
         }
         KmsiEnabled { $importSplat.EnableKmsi = $tmpValue }
         LoopDetectionEnabled {$importSplat.EnableLoopDetection = $tmpValue }
+        PersistentSsoCutoffTime { $importSplat[$tmpName] = Get-Date -Date $tmpValue }
         PersistentSsoEnabled {$importSplat.EnablePersistentSso = $tmpValue }
         InstalledLanguage {} # has no equivelent import value
         PasswordValidationDelayInMinutes {} # has no equivelent import value

--- a/adfs-management/functions/Import-ADFSProperties.ps1
+++ b/adfs-management/functions/Import-ADFSProperties.ps1
@@ -58,12 +58,23 @@
 
     $importSplat = @{}
     $ConvertedContent.psobject.properties | ForEach-Object { 
-      # some parameters are not named identically to thier respective property.  This allows translation
+      # some parameters are not simple string imports.
+      # Others have parameter naming discrepencies.
+      # Track it all here.
       $tmpName = $_.Name
       $tmpValue = $_.Value
       switch ($tmpName) {
         CertificateSharingContainer {} # has no equivelent import value
         ExtranetLockoutEnabled { $importSplat.EnableExtranetLockout = $tmpValue }
+        ExtranetObservationWindow {
+          $timespanSplat = @{
+            Days = $tmpValue.Days
+            Hours = $tmpValue.Hours
+            Minutes = $tmpValue.Minutes
+            Seconds = $tmpValue.Seconds
+          }
+          $importSplat.ExtranetObservationWindow = New-TimeSpan @timespanSplat
+        }
         KmsiEnabled { $importSplat.EnableKmsi = $tmpValue }
         LoopDetectionEnabled {$importSplat.EnableLoopDetection = $tmpValue }
         PersistentSsoEnabled {$importSplat.EnablePersistentSso = $tmpValue }

--- a/adfs-management/functions/convertorganization.ps1
+++ b/adfs-management/functions/convertorganization.ps1
@@ -4,8 +4,8 @@
   Param
   (
     [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
-    [ValidateSet("tocustom","applycustom")]
-    [string] $Method = "tocustom",
+    [ValidateSet("getcustom","applycustom")]
+    [string] $Method = "getcustom",
 
     [Parameter(Mandatory = $false, ValueFromPipeline = $false)]
     [PsObject] $Organization,

--- a/adfs-management/functions/convertorganization.ps1
+++ b/adfs-management/functions/convertorganization.ps1
@@ -1,0 +1,55 @@
+﻿function convertorganization {
+
+  [CmdletBinding()]
+  Param
+  (
+    [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+    [ValidateSet("tocustom","fromcustom")]
+    [string] $Method = "tocustom",
+
+    [Parameter(Mandatory = $false, ValueFromPipeline = $false)]
+    [PsObject] $organization
+
+  )
+
+  $ErrorActionPreference = "Stop"
+
+  If ($null -eq $organization) { return $null; end }
+  $customOrganization = $null
+
+  switch ($Method) {
+    tocustom {
+      # trim object down to configuratble entries only
+      $customOrganization = New-Object -TypeName PSObject 
+      $noteCount = 0
+      $organization.psobject.properties | ForEach-Object {
+        $tmpName = $_.Name
+        $tmpValue = $_.Value
+        If ($tmpValue) {
+          $customContact | Add-Member NoteProperty -Name $tmpName -Value $tmpValue
+          $noteCount ++
+        }
+      }
+      #check the number of properties added; if 0 then null the object
+      If ($noteCount -eq 0) { $customOrganization = $null }
+    }
+
+    fromcustom {
+
+      $splatOrganization = @{}
+      $organization.psobject.properties | ForEach-Object {
+        $tmpName = $_.Name
+        $tmpValue = $_.Value
+        If ($tmpValue) {
+          $splatOrganization[$tmpName] = $tmpValue
+        }
+      }
+      # only attempt to build splat isn't emptyu
+      If ($splatOrganization -ne @{}) {
+        $customOrganization = New-AdfsOrganization @splatOrganization
+      }
+    }
+  }
+
+  return $customOrganization
+}

--- a/adfs-management/functions/convertperson.ps1
+++ b/adfs-management/functions/convertperson.ps1
@@ -1,0 +1,65 @@
+﻿function convertperson {
+
+  [CmdletBinding()]
+  Param
+  (
+    [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+    [ValidateSet("tocustom","fromcustom")]
+    [string] $Method = "tocustom",
+
+    [Parameter(Mandatory = $false, ValueFromPipeline = $false)]
+    [PsObject] $Contact
+
+  )
+
+  $ErrorActionPreference = "Stop"
+
+  If ($null -eq $Contact) { return $null; end }
+  $customContact = $null
+
+  switch ($Method) {
+    tocustom {
+
+      # trim object down to configuratble entries only
+      $customContact = New-Object -TypeName PSObject 
+      $noteCount = 0
+      $Contact.psobject.properties | ForEach-Object {
+        $tmpName = $_.Name
+        $tmpValue = $_.Value
+        If ($tmpValue) {
+          switch ($tmpName) {
+            ContactType {} # ensure we skip this value
+            default { 
+              $customContact | Add-Member NoteProperty -Name $tmpName -Value $tmpValue
+              $noteCount ++
+            }
+          }
+        }
+      }
+      #check the number of prperties added; if 0 then null the object
+      If ($noteCount -eq 0) { $customContact = $null }
+    }
+
+    fromcustom {
+
+      $splatPerson = @{}
+      $Contact.psobject.properties | ForEach-Object {
+        $tmpName = $_.Name
+        $tmpValue = $_.Value
+        If ($tmpValue) {
+          switch ($tmpName) {
+            EmailAddresses { $splatPerson.EmailAddress = $tmpValue }
+            PhoneNumbers { $splatPerson.TelephoneNumber = $tmpValue }
+            default { $splatPerson[$tmpName] = $tmpValue }
+          }
+        }
+      }
+      # only attempt to build splat isn't emptyu
+      If ($splatPerson -ne @{}) {
+        $customContact = New-AdfsContactPerson @splatPerson
+      }
+    }
+  }
+
+  return $customContact
+}

--- a/adfs-management/functions/convertperson.ps1
+++ b/adfs-management/functions/convertperson.ps1
@@ -8,7 +8,10 @@
     [string] $Method = "tocustom",
 
     [Parameter(Mandatory = $false, ValueFromPipeline = $false)]
-    [PsObject] $Contact
+    [PsObject] $Contact,
+
+    [Parameter(Mandatory = $false)]
+    [hashtable] $SessionInfo = @{ SourceRemote = $false }
 
   )
 
@@ -56,7 +59,13 @@
       }
       # only attempt to build splat isn't emptyu
       If ($splatPerson -ne @{}) {
-        $customContact = New-AdfsContactPerson @splatPerson
+        if ($Sessioninfo.SourceRemote){
+          $command = { New-AdfsContactPerson @Using:splatPerson }
+          $customContact = Invoke-Command -Session $sessioninfo.SessionData -ScriptBlock $command
+        }
+        else {
+          $customContact = New-AdfsContactPerson @splatPerson
+        }
       }
     }
   }

--- a/pipeline/analyzer.profile
+++ b/pipeline/analyzer.profile
@@ -1,0 +1,4 @@
+@{
+    Severity = @('Error', 'Warning')
+    ExcludeRules = 'PSUseSingularNouns'
+}

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -17,3 +17,4 @@ jobs:
     parameters:
       module_name: adfs-management
       module_version: $(majorMinorVersion).$(semanticVersion)
+      analyzer_profile: '.\\pipeline\\analyzer.profile'


### PR DESCRIPTION
Now will export the common properties available from `get-adfsproperties'.
- `export-adfsproperties` exports all values into a JSON format
- `import-adfsproperties` imports all defined values from JSON
- all import properties have been standardized based on export name to minimize refactoring