### PR TITLE
Module check

### DIFF
--- a/adfs-management/adfs-management.psd1
+++ b/adfs-management/adfs-management.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion = '1.2.0'
+    ModuleVersion = '1.3.0'
     GUID = '0ad55c54-b693-4636-9375-4877987bfdb0'
     Author = 'Justin King'
     CompanyName = 'Unknown'
@@ -16,6 +16,7 @@
       '.\functions\Import-ADFSClaimRule.ps1',
       '.\functions\Import-ADFSClient.ps1',
       '.\functions\Import-ADFSProperties.ps1',
+      '.\functions\modulechecker.ps1',
       '.\functions\sessionconfig.ps1'
     )
     FunctionsToExport = @(

--- a/adfs-management/functions/Export-ADFSClaimRule.ps1
+++ b/adfs-management/functions/Export-ADFSClaimRule.ps1
@@ -49,6 +49,9 @@
         }
         If ($Credential) { $params.Credential = $Credential }
         $sessioninfo = sessionconfig @params
+
+        # Check for required Modules
+        modulechecker -SessionInfo $sessioninfo
     }
 
     Process

--- a/adfs-management/functions/Export-ADFSClient.ps1
+++ b/adfs-management/functions/Export-ADFSClient.ps1
@@ -44,6 +44,9 @@
         }
         If ($Credential) { $params.Credential = $Credential }
         $sessioninfo = sessionconfig @params
+        
+        # Check for required Modules
+        modulechecker -SessionInfo $sessioninfo
     }
 
     Process

--- a/adfs-management/functions/Export-ADFSProperties.ps1
+++ b/adfs-management/functions/Export-ADFSProperties.ps1
@@ -37,6 +37,9 @@
         }
         If ($Credential) { $params.Credential = $Credential }
         $sessioninfo = sessionconfig @params
+        
+        # Check for required Modules
+        modulechecker -SessionInfo $sessioninfo
     }
 
     Process

--- a/adfs-management/functions/Import-ADFSClaimRule.ps1
+++ b/adfs-management/functions/Import-ADFSClaimRule.ps1
@@ -53,6 +53,9 @@
     }
     If ($Credential) { $params.Credential = $Credential }
     $sessioninfo = sessionconfig @params
+    
+    # Check for required Modules
+    modulechecker -SessionInfo $sessioninfo
   }
 
   Process {

--- a/adfs-management/functions/Import-ADFSClient.ps1
+++ b/adfs-management/functions/Import-ADFSClient.ps1
@@ -48,6 +48,9 @@
     }
     If ($Credential) { $params.Credential = $Credential }
     $sessioninfo = sessionconfig @params
+    
+    # Check for required Modules
+    modulechecker -SessionInfo $sessioninfo
   }
 
   Process {

--- a/adfs-management/functions/Import-ADFSProperties.ps1
+++ b/adfs-management/functions/Import-ADFSProperties.ps1
@@ -51,6 +51,10 @@
     }
     If ($Credential) { $params.Credential = $Credential }
     $sessioninfo = sessionconfig @params
+
+    
+    # Check for required Modules
+    modulechecker -SessionInfo $sessioninfo
   }
 
   Process {

--- a/adfs-management/functions/modulechecker.ps1
+++ b/adfs-management/functions/modulechecker.ps1
@@ -16,7 +16,6 @@
   )
   
   $ErrorActionPreference = "Stop"
-  $modulesFound = $true
   $missingModules = @()
 
   $PSModules | ForEach-Object {
@@ -34,11 +33,10 @@
     If ($null -eq $results) {
       $currentModule.Status = "Missing"
       $missingModules += $currentModule
-      $modulesFound = $false
     }
   }
 
-  If (!$modulesFound) {
+  If ($missingModules -ne @()) {
     Write-Output "Summary:"
     $missingModules
     Write-Error "Required modules are missing, cannot continue." -ErrorAction Stop

--- a/adfs-management/functions/modulechecker.ps1
+++ b/adfs-management/functions/modulechecker.ps1
@@ -1,0 +1,47 @@
+﻿function modulechecker {
+
+  [CmdletBinding()]
+  Param
+  (
+    [Parameter(Mandatory = $false)]
+    [hashtable] $SessionInfo = @{ SourceRemote = $false },
+
+    [Parameter(Mandatory = $false)]
+    [Array]$PSModules = @(
+      @{ 
+        ModuleName = "ADFS" 
+        ModuleVersion = "1.0.0.0"
+      }
+    )
+  )
+  
+  $ErrorActionPreference = "Stop"
+  $modulesFound = $true
+  $missingModules = @()
+
+  $PSModules | ForEach-Object {
+    $currentModule = $_
+    switch ($SessionInfo.SourceRemote) {
+      $true {
+        $command = { Get-Module -ListAvailable -FullyQualifiedName $Using:currentModule }
+        $results = Invoke-Command -Session $sessioninfo.SessionData -ScriptBlock $command
+      }
+      $false {
+        $results = Get-Module -ListAvailable -FullyQualifiedName $currentModule
+      }
+    }
+
+    If ($null -eq $results) {
+      $currentModule.Status = "Missing"
+      $missingModules += $currentModule
+      $modulesFound = $false
+    }
+  }
+
+  If (!$modulesFound) {
+    Write-Output "Summary:"
+    $missingModules
+    Write-Error "Required modules are missing, cannot continue." -ErrorAction Stop
+  }
+
+}


### PR DESCRIPTION
added a custom module check.  This is due to the issue that ADFS module can only run against local resources, so it needs to be tested against potential remote resources when necessary.

`export-adfsproperties` has been tested and enabled in this release.